### PR TITLE
feat: update `MoneyV2` fields for `2.17.0`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for shopify-buy 2.14
+// Type definitions for shopify-buy 2.17
 // Project: https://github.com/Shopify/js-buy-sdk#readme
 // Definitions by: Martin Köhn <https://github.com/openminder>
 //                 Stephen Traiforos <https://github.com/straiforos>
@@ -663,7 +663,7 @@ declare module ShopifyBuy {
     /**
     * The price of the product variant in the default shop currency.
     */
-    price: string
+    price: MoneyV2
     /**
     * The weight of the product variant in the unit system specified with weight_unit.
     */
@@ -679,7 +679,7 @@ declare module ShopifyBuy {
     /**
     * The compare-at price of the variant in the default shop currency.
     */
-    compareAtPrice: string
+    compareAtPrice: MoneyV2
     /**
     * The price of the product variant in the default shop currency.
     */
@@ -702,17 +702,9 @@ declare module ShopifyBuy {
     */
     image: Image
     /**
-    * The compare-at price of the variant in the default shop currency.
-    */
-    compareAtPriceV2: MoneyV2
-    /**
     * List of prices and compare-at prices in the presentment currencies for this shop.
     */
     presentmentPrices: PresentmentPrices[]
-    /**
-    * The price of the product variant in the default shop currency.
-    */
-    priceV2: MoneyV2
   }
 
   export interface LineItem extends GraphModel {
@@ -772,11 +764,11 @@ declare module ShopifyBuy {
     /**
     * The amount that was taken from the gift card by applying it.
     */
-    amountUsedV2: MoneyV2
+    amountUsed: MoneyV2
     /**
     * The amount left on the gift card.
     */
-    balanceV2: MoneyV2
+    balance: MoneyV2
     /**
     * A globally-unique identifier.
     */
@@ -811,7 +803,7 @@ declare module ShopifyBuy {
     /**
     * The amount left to be paid. This is equal to the cost of the line items, duties, taxes and shipping minus discounts and gift cards.
     */
-    paymentDue: string
+    paymentDue: MoneyV2
     /**
     * The url pointing to the checkout accessible from the web.
     */
@@ -835,15 +827,15 @@ declare module ShopifyBuy {
     /**
     * The sum of all the taxes applied to the line items and shipping lines in the checkout.
     */
-    totalTax: string
+    totalTax: MoneyV2
     /**
     * Price of the checkout before duties, shipping and taxes.
     */
-    subtotalPrice: string
+    subtotalPrice: MoneyV2
     /**
     * The sum of all the prices of all the items in the checkout, duties, taxes and discounts included.
     */
-    totalPrice: string
+    totalPrice: MoneyV2
     /**
     * The date and time when the checkout was completed.
     */
@@ -890,25 +882,9 @@ declare module ShopifyBuy {
     */
     discountApplications: string[]
     /**
-    * The sum of all the prices of all the items in the checkout, duties, taxes and discounts included.
-    */
-    totalPriceV2: MoneyV2
-    /**
-    * Price of the checkout before duties, shipping and taxes.
-    */
-    subtotalPriceV2: MoneyV2
-    /**
     * The sum of all the prices of all the items in the checkout. Duties, taxes, shipping and discounts excluded.
     */
     lineItemsSubtotalPrice: MoneyV2
-    /**
-    * The sum of all the taxes applied to the line items and shipping lines in the checkout.
-    */
-    totalTaxV2: MoneyV2
-    /**
-    * The amount left to be paid. This is equal to the cost of the line items, duties, taxes and shipping minus discounts and gift cards.
-    */
-    paymentDueV2: MoneyV2
     /**
     * TODO
     */
@@ -920,7 +896,7 @@ declare module ShopifyBuy {
     /**
     * TODO
     */
-    onlineStoreUrl: string | null
+    onlineStoreUrl: string | undefined
   }
 
   export interface Collection {

--- a/index.d.ts
+++ b/index.d.ts
@@ -702,9 +702,17 @@ declare module ShopifyBuy {
     */
     image: Image
     /**
+    * @deprecated The compare-at price of the variant in the default shop currency.
+    */
+    compareAtPriceV2: MoneyV2
+    /**
     * List of prices and compare-at prices in the presentment currencies for this shop.
     */
     presentmentPrices: PresentmentPrices[]
+    /**
+    * @deprecated The price of the product variant in the default shop currency.
+    */
+    priceV2: MoneyV2
   }
 
   export interface LineItem extends GraphModel {
@@ -766,9 +774,17 @@ declare module ShopifyBuy {
     */
     amountUsed: MoneyV2
     /**
+    * @deprecated The amount that was taken from the gift card by applying it.
+    */
+    amountUsedV2: MoneyV2
+    /**
     * The amount left on the gift card.
     */
     balance: MoneyV2
+    /**
+    * @deprecated The amount left on the gift card.
+    */
+    balanceV2: MoneyV2
     /**
     * A globally-unique identifier.
     */
@@ -882,9 +898,25 @@ declare module ShopifyBuy {
     */
     discountApplications: string[]
     /**
+    * @deprecated The sum of all the prices of all the items in the checkout, duties, taxes and discounts included.
+    */
+    totalPriceV2: MoneyV2
+    /**
+    * @deprecated Price of the checkout before duties, shipping and taxes.
+    */
+    subtotalPriceV2: MoneyV2
+    /**
     * The sum of all the prices of all the items in the checkout. Duties, taxes, shipping and discounts excluded.
     */
     lineItemsSubtotalPrice: MoneyV2
+    /**
+    * @deprecated The sum of all the taxes applied to the line items and shipping lines in the checkout.
+    */
+    totalTaxV2: MoneyV2
+    /**
+    * @deprecated The amount left to be paid. This is equal to the cost of the line items, duties, taxes and shipping minus discounts and gift cards.
+    */
+    paymentDueV2: MoneyV2
     /**
     * TODO
     */


### PR DESCRIPTION
According to the `2.17.0` release notes:
> NOTABLE API DATA CHANGE: Storefront API version 2022-10 includes the removal of the Money scalar and all fields that had previously returned a [Money](https://shopify.dev/api/storefront/2022-07/scalars/Money) scalar will now return a [MoneyV2](https://shopify.dev/api/storefront/2022-10/objects/MoneyV2) object. Affected fields include:
> - AppliedGiftCard fields: amountUsed, balance
> - Checkout fields: paymentDue, totalTax, subtotalPrice, totalPrice
> - ShippingRate fields: price
> - Order fields: subtotalPrice, totalShippingPrice, totalTax, totalPrice, totalRefunded
> - ProductVariant fields: price, compareAtPrice

Not all the definitions above are present here, so this PR only:
- removes the deprecated fields
- updates the string-based counterparts that were originally based on the `Money` Scalar.